### PR TITLE
Add Privacy Policy and Terms & Conditions pages

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Privacy Policy</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; background: #f9f9f9; }
+    h1 { color: #333; }
+    p { line-height: 1.6; color: #555; }
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p>
+    This website uses third-party advertisements provided by Adsterra. These ads may use cookies or web beacons when they advertise on our site, which will send these advertisers (such as Adsterra) information including your IP address, your ISP, the browser you used to visit our site, and in some cases, whether you have Flash installed.
+  </p>
+  <p>
+    This is generally used for geotargeting purposes (showing


### PR DESCRIPTION
This pull request adds two new pages:

- `privacy.html`: Contains the website's privacy policy, required for Adsterra ad compliance.
- `terms.html`: Outlines the terms and conditions for using our web tools.

These pages are necessary to inform users about data usage and legal terms, especially when using third-party ad services.

Also updated the main index.html footer to include links to these pages.
