### PR TITLE
Add Privacy Policy and Terms & Conditions pages

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Terms & Conditions</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      max-width: 800px;
+      margin: 40px auto;
+      padding: 20px;
+      line-height: 1.6;
+      background-color: #f9f9f9;
+      color: #333;
+    }
+    h1 {
+      color: #444;
+    }
+  </style>
+</head>
+<body>
+  <h1>Terms & Conditions</h1>
+  <p>
+    By using this website, you agree to the following terms:
+  </p>
+  <ul>
+    <li>This website offers free online tools as-is, without any warranty.</li>
+    <li>We are not responsible for any errors or misuse of the tool’s results.</li>
+    <li>You agree not to use this site for any illegal or harmful activity.</li>
+  </ul>
+  <p>
+    We reserve the right to change these terms at any time without notice. Please check back periodically.
+  </p>
+</body>
+</html>


### PR DESCRIPTION
This pull request adds two new pages:

- `privacy.html`: Contains the website's privacy policy, required for Adsterra ad compliance.
- `terms.html`: Outlines the terms and conditions for using our web tools.

These pages are necessary to inform users about data usage and legal terms, especially when using third-party ad services.

Also updated the main index.html footer to include links to these pages.
